### PR TITLE
More general facility for redrawing plots

### DIFF
--- a/R/evals.R
+++ b/R/evals.R
@@ -1126,7 +1126,6 @@ redrawPlot <- function(recPlot)
             if(is(res, "error"))
                 stop(res)
         } else {
-            #start code from pander package
             if (getRversion() < "3.0.0") {
                 for (i in 1:length(recPlot[[1]])) #@jeroenooms
                     if ("NativeSymbolInfo" %in% class(recPlot[[1]][[i]][[2]][[1]])) 
@@ -1148,6 +1147,5 @@ redrawPlot <- function(recPlot)
                 }
             }
             suppressWarnings(grDevices::replayPlot(recPlot))
-            #end code from pander package
         }
 }


### PR DESCRIPTION
I created the redrawPlot function which can handle grid/trellis/ggplot2 objects as well as recordedplot objects (including ones that were saved and loaded).

I redefined redraw.recordedplot to be a simple wrapper around the new redrawPlot that behaves identically to how it did before. (This function name is not really appropriate as it indicates that it is an s3 method for a function called redraw that accepts a recordedplot object, but it infact expects a character filepath, but changing that is beyond my purview so I left it as is).

I did not rerun roxygen(2), but did document the new function and change the documentation of the old function so that NAMESPACE and doc files will be updated when that is run again.

Let me know if you have any questions or concerns

~G
