### PR TITLE
Fix for issue #86

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -597,6 +597,8 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
                 }
               }
             }
+          }else{
+            x <- gsub("^\\s+|\\s+$", "", x)
           }
           ## return
           if (is.na(x))
@@ -710,7 +712,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     if (keep.trailing.zeros)
         t <- format(t, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark)
     else
-        t <- format(t, trim = TRUE)
+        t <- format(t, trim = TRUE)  ### here adds unneeded zero's
 
     ## adding formatting (emphasis, strong etc.)
     if (length(dim(t)) < 2) {


### PR DESCRIPTION
Fix for issue #86. For simple and rmarkdown trailing white spaces were not removed in split.large.cells, so it was resulting in wrong rendering. This change only affects rendering for 'simple' and 'rmakdown' styles.

```
d> pander(col.table.transposed, style="simple", justify="right") 

------------ ----
    **blue**    2
  **orange**   13
     **red**  108
  **yellow** 1780
------------ ----

d> pander(col.table, style="simple", justify="center")


 blue   orange   red   yellow 
------ -------- ----- --------
  2       13     108    1780  
```
