### PR TITLE
Implementation of possibility to specify max width of the column separately with a vector

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -595,8 +595,11 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
             for (line in lines){
               sl <- split.line(line)    
               x <- paste0(x, sl, sep="\n")
-           }
-	}
+            }
+	        }
+        }
+      } else {
+        x <- gsub("^\\s+|\\s+$", "", x)
       }
       ## return
       if (is.na(x))
@@ -1026,7 +1029,7 @@ pandoc.formula <- function(...)
 #' pandoc.date(Sys.Date())
 #' pandoc.date(Sys.Date() - 1:10)
 #' pandoc.date(Sys.Date() - 1:10, inline = FALSE)
-pandoc.date.return <- function(x, inline = TRUE, simplified = FALSE)
+pandoc.date.return <- function(x, inline = TRUE, simplified = FALSE){
   if (length(x) == 1 || simplified){
     format(x, format = panderOptions('date'))
   } else {  
@@ -1035,7 +1038,9 @@ pandoc.date.return <- function(x, inline = TRUE, simplified = FALSE)
     else
       pandoc.list.return(as.list((format(x, format = panderOptions('date')))), add.end.of.list = FALSE)
   }
+}
 
 #' @export
-pandoc.date <- function(...)
+pandoc.date <- function(...){
   cat(pandoc.date.return(...))
+}


### PR DESCRIPTION
So whole implementation is based around such pronciples:
1. If split.cells is just a number, behavior is the same as before.
2. First value in split.cells goes for row names, if there are no row names, then it goes for first param.
3. If length(split.cells) == number of columns, then there is one max.width for every column and for rownames (if they exists) default value will be used
4. If length(split.cells) == number of columns + 1, then first value in split.cells if for row names, and others are for columns.
5. All extra value in split.cells vector are discarded.
6. If split.cells does not have enough values for all columns, warning is produced and default values are added for other columns.

_Creating dummy data_ 

```
y <- c("aa aa aa", "aaa aaa", "a a a a a", "aaaaa", "bbbb bbbb bbbb", "bb bbb bbbb")
y <- matrix(y, ncol = 3, nrow = 2)
rownames(y) <- c("rowname one", "rowname two")
colnames(y) <- c("colname one", "colname two", "colname three")
```

**Examples for each of the things listed.**

_If split.cells is just a number, behavior is the same as before._

```
d> pander(y, split.cells = 2)

-----------------------------------------
  &nbsp;     colname   colname   colname 
               one       two      three  
----------- --------- --------- ---------
 **rowname     aa         a       bbbb   
   one**       aa         a       bbbb   
               aa         a       bbbb   
                          a              
                          a              

 **rowname     aaa      aaaaa      bb    
   two**       aaa                 bbb   
                                  bbbb   
-----------------------------------------

d> pander(y, split.cells = 6)

-----------------------------------------
  &nbsp;     colname   colname   colname 
               one       two      three  
----------- --------- --------- ---------
 **rowname    aa aa     a a a     bbbb   
   one**       aa        a a      bbbb   
                                  bbbb   

 **rowname     aaa      aaaaa      bb    
   two**       aaa                 bbb   
                                  bbbb   
-----------------------------------------
```

_If length(split.cells) == number of columns, then there is one max.width for every column and for rownames (if they exists) default value will be used_ 

```
d> pander(y, split.cells = c(2, 6, 10))

-----------------------------------------------
     &nbsp;        colname   colname   colname 
                     one       two      three  
----------------- --------- --------- ---------
 **rowname one**     aa       a a a   bbbb bbbb
                     aa        a a      bbbb   
                     aa                        

 **rowname two**     aaa      aaaaa    bb bbb  
                     aaa                bbbb   
-----------------------------------------------

d> pander(y, split.cells = c(2, Inf, Inf))

---------------------------------------------------------
     &nbsp;        colname   colname two   colname three 
                     one                                 
----------------- --------- ------------- ---------------
 **rowname one**     aa       a a a a a   bbbb bbbb bbbb 
                     aa                                  
                     aa                                  

 **rowname two**     aaa        aaaaa       bb bbb bbbb  
                     aaa                                 
---------------------------------------------------------
```

_If length(split.cells) == number of columns + 1, then first value in split.cells if for row names, and others are for columns._

```
d> pander(y, split.cells = c(5, 2, Inf, Inf))

---------------------------------------------------
  &nbsp;     colname   colname two   colname three 
               one                                 
----------- --------- ------------- ---------------
 **rowname     aa       a a a a a   bbbb bbbb bbbb 
   one**       aa                                  
               aa                                  

 **rowname     aaa        aaaaa       bb bbb bbbb  
   two**       aaa                                 
---------------------------------------------------

```

_All extra value in split.cells vector are discarded._

```
d> pander(y, split.cells = c(5, 2, Inf, 5, 3, 10))

---------------------------------------------
  &nbsp;     colname   colname two   colname 
               one                    three  
----------- --------- ------------- ---------
 **rowname     aa       a a a a a     bbbb   
   one**       aa                     bbbb   
               aa                     bbbb   

 **rowname     aaa        aaaaa        bb    
   two**       aaa                     bbb   
                                      bbbb   
---------------------------------------------
```

_If split.cells does not have enough values for all columns, warning is produced and default values are added for other columns._

```
d> pander(y, split.cells = c(5, 2))

-----------------------------------------------------
     &nbsp;        colname   colname   colname three 
                     one       two                   
----------------- --------- --------- ---------------
 **rowname one**     aa         a     bbbb bbbb bbbb 
                     aa         a                    
                     aa         a                    
                                a                    
                                a                    

 **rowname two**     aaa      aaaaa     bb bbb bbbb  
                     aaa                             
-----------------------------------------------------

Warning messages:
1: In split.large.cells(t) :
  Split.cells vectors is smaller than data. Default value will be used for other cells
2: In split.large.cells(t.colnames) :
  Split.cells vectors is smaller than data. Default value will be used for other cells

d> pander(y, split.cells = c(5, Inf))

---------------------------------------------------------
     &nbsp;        colname   colname two   colname three 
                     one                                 
----------------- --------- ------------- ---------------
 **rowname one**     aa       a a a a a   bbbb bbbb bbbb 
                     aa                                  
                     aa                                  

 **rowname two**     aaa        aaaaa       bb bbb bbbb  
                     aaa                                 
---------------------------------------------------------

Warning messages:
1: In split.large.cells(t) :
  Split.cells vectors is smaller than data. Default value will be used for other cells
2: In split.large.cells(t.colnames) :
  Split.cells vectors is smaller than data. Default value will be used for other cells

```
