### PR TITLE
Added handling for more convenient justify parameter passing

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -967,7 +967,14 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         if (length(justify) != length(t.width))
             stop(sprintf('Wrong number of parameters (%s instead of *%s*) passed: justify', length(justify), length(t.width)))
     } else {
-        justify <- rep(justify, length(t.width))
+        if (all (strsplit(justify, "")[[1]] %in% c("c", "l", "r") )) {
+          if (nchar(justify) != length(t.width))
+            stop(sprintf('Wrong number of parameters (%s instead of *%s*) passed: justify', nchar(justify), length(t.width)))
+          
+          justify <- c(l = "left", c = "centre", r = "right")[ strsplit(justify, "")[[1]] ]  
+        } else {
+          justify <- rep(justify, length(t.width))
+        }
     }
     justify <- sub('^center$', 'centre', justify)
     if (!all(justify %in% c('left', 'right', 'centre')))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -468,7 +468,7 @@ pandoc.list <- function(...)
 #' @param big.mark passed to \code{format}
 #' @param round passed to \code{round}
 #' @param missing string to replace missing values
-#' @param justify defines alignment in cells passed to \code{format}. Can be \code{left}, \code{right} or \code{centre}, which latter can be also spelled as \code{center}. Defaults to \code{centre}.
+#' @param justify defines alignment in cells passed to \code{format}. Can be \code{left}, \code{right} or \code{centre}, which latter can be also spelled as \code{center}. Defaults to \code{centre}. Can be abbreviated to a string consisting of the letters \code{l}, \code{c} and \code{r} (e.g. 'lcr' instead of c('left', 'centre', 'right').
 #' @param style which Pandoc style to use: \code{simple}, \code{multiline}, \code{grid} or \code{rmarkdown}
 #' @param split.tables where to split wide tables to separate tables. The default value (\code{80}) suggests the conventional number of characters used in a line, feel free to change (e.g. to \code{Inf} to disable this feature) if you are not using a VT100 terminal any more :)
 #' @param split.cells where to split cells' text with line breaks. Default to \code{30}, to disable set to \code{Inf}. Can be also supplied as a vector, for each cell separately (if length(split.cells) == number of columns + 1, then first value in split.cells if for row names, and others are for columns). Supports relative (percentage) parameters in combination with split.tables.
@@ -515,6 +515,7 @@ pandoc.list <- function(...)
 #'   c = c('a', 'bb', 'ccc', 'dddd', 'eeeee'))
 #' pandoc.table(m)
 #' pandoc.table(m, justify = c('right', 'left', 'centre'))
+#' pandoc.table(m, justify = 'rlc') # Same as upper statement
 #'
 #' ## splitting up too wide tables
 #' pandoc.table(mtcars)

--- a/man/pandoc.table.return.Rd
+++ b/man/pandoc.table.return.Rd
@@ -35,7 +35,7 @@ pandoc.table.return(t, caption, digits = panderOptions("digits"),
 
 \item{missing}{string to replace missing values}
 
-\item{justify}{defines alignment in cells passed to \code{format}. Can be \code{left}, \code{right} or \code{centre}, which latter can be also spelled as \code{center}. Defaults to \code{centre}.}
+\item{justify}{defines alignment in cells passed to \code{format}. Can be \code{left}, \code{right} or \code{centre}, which latter can be also spelled as \code{center}. Defaults to \code{centre}. Can be abbreviated to a string consisting of the letters \code{l}, \code{c} and \code{r} (e.g. 'lcr' instead of c('left', 'centre', 'right').}
 
 \item{style}{which Pandoc style to use: \code{simple}, \code{multiline}, \code{grid} or \code{rmarkdown}}
 
@@ -106,6 +106,7 @@ m <- data.frame(a = c(1, -500, 10320, 23, 77),
   c = c('a', 'bb', 'ccc', 'dddd', 'eeeee'))
 pandoc.table(m)
 pandoc.table(m, justify = c('right', 'left', 'centre'))
+pandoc.table(m, justify = 'rlc') # Same as upper statement
 
 ## splitting up too wide tables
 pandoc.table(mtcars)


### PR DESCRIPTION
Added handling for more convenient justify parameter passing. So if user needs to justify multiple columns differently, it is more convenient to pass e.g. `justify = "llcrr"` instead of `justify = c("left", "left", "centre", "right", "right")`. This is Latex style.