### PR TITLE
pandoc.table.return refactoring

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ Fixes:
  * removal of calls to deprecated functions (#172)
  * correct rendering for horizontal mtables (#174)
  * correct splitting of tables based on style (#164)
+ * correct rendering for rmarkdown tables with | (#186)
 
 New classes supported by the `pander` generic S3 method:
  * summary.table

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ Fixes:
  * missing column and row titles in CrossTable (#163)
  * removal of calls to deprecated functions (#172)
  * correct rendering for horizontal mtables (#174)
+ * correct splitting of tables based on style (#164)
 
 New classes supported by the `pander` generic S3 method:
  * summary.table

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -658,12 +658,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         ## single value and vectors/lists
         if (length(dim(cells)) < 2) {
 
-            if (length(cells) == 0) {
-
-                res <- split.single.cell(cells, split.cells[1])
-
-            } else {
-
                 ## discard first value which was for rownames
                 if (!for.rownames && (length(split.cells) >= length(cells) + 1))
                     split.cells <- split.cells[-1]
@@ -672,12 +666,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
                     warning("length of split.cells vector is smaller than data. Default value will be used for other cells")
                     split.cells <- c(split.cells, rep(panderOptions('table.split.cells'), length(cells) - length(split.cells)))
                 }
-
-                for (i in 1:length(cells))
-                    res <- c(res, split.single.cell(cells[i], max.width = split.cells[i]))
-
-            }
-
+                res <- sapply(seq_along(cells), function(x, i) split.single.cell(x[i], max.width = split.cells[i]), x = cells, USE.NAMES = FALSE)
 
         } else { # matrixes and tables
 
@@ -735,8 +724,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         }
     }
     ## converting a table to intermediate representation
-    empC <- function(x)
-        cbind(rep(1, length(x)), x)
     if (length(dim(t)) > 2){
         t <- ftable(t)
     } else if (length(dim(t)) < 2) {
@@ -746,9 +733,9 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         rownames(t) <- NULL
         # special conversion for emphasize.cells, emphasize.strong.cells
         if (!missing(emphasize.cells))
-            emphasize.cells <- empC(emphasize.cells)
+            emphasize.cells <- cbind(rep(1, length(emphasize.cells)), emphasize.cells)
         if (!missing(emphasize.strong.cells))
-            emphasize.strong.cells <- empC(emphasize.strong.cells)
+            emphasize.strong.cells <- cbind(rep(1, length(emphasize.strong.cells)), emphasize.strong.cells)
     } else if (dim(t)[1] == 0) { # check for empty objects
         if (!is.null(colnames(t))) {
             t <- as.data.frame(t)
@@ -965,7 +952,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         } else {
             justify <- list(justify[1:(t.split)], justify[c((t.split + 1):length(t.width))])
         }
-
         res <- list(t[, 1:(t.split), drop = FALSE], t[, (t.split + 1):ncol(t), drop = FALSE])
 
         ## recursive call

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -773,9 +773,23 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         }
     }
 
-    ## converting 3D+ tables to 2D
-    if (length(dim(t)) > 2)
+    ## converting a table to intermediate representation
+    if (length(dim(t)) > 2){
         t <- ftable(t)
+    } else if (length(dim(t)) < 2) {
+        tn <- names(t)
+        t <- rbind(matrix(nrow = 0, ncol = length(t)), t)
+        colnames(t) <- tn
+        rownames(t) <- NULL
+    } else if (dim(t)[1] == 0) { # check for empty objects
+        if (!is.null(colnames(t))) {
+            t <- as.data.frame(t)
+            t[1, ] <- NA
+        } else {
+            warning("Object is empty and without header. No output will be produced")
+            return(invisible())
+        }
+    }
 
     ## initializing
     mc  <- match.call()
@@ -820,17 +834,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     ## store missing values
     wm <- which(is.na(t), arr.ind = TRUE)
 
-    ## checking for empty data frames
-    if (length(dim(t)) > 1 && dim(t)[1] == 0) {
-        if (!is.null(colnames(t))) {
-            t <- as.data.frame(t)
-            t[1, ] <- NA
-        } else {
-            warning("Object is empty and without header. No output will be produced")
-            return(invisible())
-        }
-    }
-    
     ## round numbers & cut digits & apply decimal mark & optionally remove trailing zeros
     if (length(dim(t)) < 2 | !is.null(dim(t)) && length(dim(t)) == 2 && is.data.frame(t))
         t.n <- as.numeric(which(sapply(t, is.numeric)))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -761,16 +761,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
 
     ## check for relative split.cells
     if (all(grepl("%$", split.cells))){
-        d <- 0
-        if (length(dim(t)) < 2){
-            if (length(dim(t)) == 0){
-                d <- length(t)
-            }else{
-                d <- dim(t)[1]
-            }
-        }else{
-            d <- dim(t)[2]
-        }
+        d <- dim(t)[2]
         split.cells <- as.numeric(gsub("%$","",split.cells))
         if (sum(split.cells) == 100){
             if (is.infinite(split.tables)){
@@ -791,8 +782,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
             split.cells <- panderOptions("table.split.cells")
         }
     }
-
-
 
     ## initializing
     mc  <- match.call()
@@ -817,8 +806,8 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
             caption <- attr(t, 'caption')
         }
     }
-    emphasize.parameters <- c('emphasize.rows', 'emphasize.cols', 'emphasize.cells', 'emphasize.strong.rows', 'emphasize.strong.cols', 'emphasize.strong.cells')
     ## check if emphasize parameters were passed
+    emphasize.parameters <- c('emphasize.rows', 'emphasize.cols', 'emphasize.cells', 'emphasize.strong.rows', 'emphasize.strong.cols', 'emphasize.strong.cells')
     if (all(sapply(emphasize.parameters, function(p) is.null(mc[[p]]), USE.NAMES = FALSE))) {
         ## check if emphasize parameters were set in attributes
         if (all(sapply(emphasize.parameters, function(p) is.null(attr(t, p)), USE.NAMES = FALSE)))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -835,37 +835,29 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     wm <- which(is.na(t), arr.ind = TRUE)
 
     ## round numbers & cut digits & apply decimal mark & optionally remove trailing zeros
-    if (length(dim(t)) < 2 | !is.null(dim(t)) && length(dim(t)) == 2 && is.data.frame(t))
-        t.n <- as.numeric(which(sapply(t, is.numeric)))
-    else
-        t.n <- as.numeric(which(apply(t, 2, is.numeric)))
+    t.n <- as.numeric(which(apply(t, 2, is.numeric)))
     if (length(t.n) > 0) {
-        if (length(dim(t)) == 2)
-            t[, t.n] <- apply(t[, t.n, drop = FALSE], 2, round, digits = round)
-        else
-            t[t.n]   <- round(t[t.n], round)
-        if (!keep.trailing.zeros) {
-            switch(as.character(length(dim(t))),
-                   '0' = t[t.n]   <- sapply(t[t.n], format, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark),
-                   '1' = t[t.n]   <- apply(t[t.n, drop = FALSE], 1, format, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark),
-                   '2' = t[, t.n] <- apply(t[, t.n, drop = FALSE], c(1,2), format, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark)
-                   )
-        }
+        t[, t.n] <- apply(t[, t.n, drop = FALSE], 2, round, digits = round)
+        if (!keep.trailing.zeros)
+            t[, t.n] <- apply(t[, t.n, drop = FALSE], c(1,2), format, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark)
     }
 
     ## drop unexpected classes and revert back to a common format
-    if (keep.trailing.zeros)
+    if (keep.trailing.zeros) {
         t <- format(t, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark)
-    else
+    } else {
         t <- format(t, trim = TRUE)  ### here adds unneeded zero's
+    }
     ## force possible factors to character vectors
     wf <- which(sapply(t, is.factor))
-    if (length(dim(t)) == 2 && length(wf) > 0)
+    if (length(dim(t)) == 2 && length(wf) > 0) {
         t[, wf] <- apply(t[wf], 2, as.character)
+    }
 
     ## replace missing values
-    if (length(wm) > 0)
+    if (length(wm) > 0) {
         t[wm] <- missing
+    }
 
     ## adding formatting (emphasis, strong etc.)
     if (length(dim(t)) < 2) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -901,7 +901,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     if (length(t.rownames) != 0) {
 
         if ((length(split.cells) <= dim(t)[2]) && (length(split.cells) > 1))
-            split.cells <- c(30, split.cells)
+            split.cells <- c(panderOptions("table.split.cells"), split.cells)
         t.rownames <- split.large.cells(t.rownames, TRUE)
 
         if (!is.null(t.colnames))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -608,12 +608,14 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
 
     ## split single cell with line breaks based on max.width
     split.single.cell <- function(x, max.width){
-        if (!is.character(x))
+        if (!is.character(x)) {
             x <- as.character(x)
+        }
         ## as.character(NA) remains NA, which causes isses with nchar since 2015-04-23
         ## https://stat.ethz.ch/pipermail/r-devel/2015-April/071007.html
-        if (is.na(x))
+        if (is.na(x)) {
             x <- 'NA'
+        }
         if (!style %in% c('simple', 'rmarkdown')) {
             ## split
             if (nchar(x) == nchar(encodeString(x)) && !use.hyphening) {
@@ -648,10 +650,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         }
 
         ## if we have a single value, extend it to a vector to do less checks laters
-        if (length(split.cells) == 1)
+        if (length(split.cells) == 1) {
             split.cells <- rep(split.cells, length(cells))
-        if (for.rownames) # in case it is used for rownames, we only need the first value
+        }
+        if (for.rownames) { # in case it is used for rownames, we only need the first value
             split.cells <- rep(split.cells[1], length(cells))
+        }
 
         res <- NULL
 
@@ -659,8 +663,9 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         if (length(dim(cells)) < 2) {
 
                 ## discard first value which was for rownames
-                if (!for.rownames && (length(split.cells) >= length(cells) + 1))
+                if (!for.rownames && (length(split.cells) >= length(cells) + 1)) {
                     split.cells <- split.cells[-1]
+                }
 
                 if (length(cells) > length(split.cells)) {
                     warning("length of split.cells vector is smaller than data. Default value will be used for other cells")
@@ -679,8 +684,9 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
                 split.cells <- c(split.cells, rep(panderOptions('table.split.cells'), dim(cells)[2] - length(split.cells)))
             }
 
-            for (j in 1:dim(cells)[2])
+            for (j in 1:dim(cells)[2]) {
                 res <- cbind(res, sapply(cells[,j], split.single.cell, max.width = split.cells[j], USE.NAMES = FALSE))
+            }
 
         }
 
@@ -732,10 +738,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         colnames(t) <- tn
         rownames(t) <- NULL
         # special conversion for emphasize.cells, emphasize.strong.cells
-        if (!missing(emphasize.cells))
+        if (!missing(emphasize.cells)) {
             emphasize.cells <- cbind(rep(1, length(emphasize.cells)), emphasize.cells)
-        if (!missing(emphasize.strong.cells))
+        }
+        if (!missing(emphasize.strong.cells)) {
             emphasize.strong.cells <- cbind(rep(1, length(emphasize.strong.cells)), emphasize.strong.cells)
+        }
     } else if (dim(t)[1] == 0) { # check for empty objects
         if (!is.null(colnames(t))) {
             t <- as.data.frame(t)
@@ -772,10 +780,11 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
 
     ## initializing
     mc  <- match.call()
-    if (is.null(mc$style))
+    if (is.null(mc$style)) {
         style <- panderOptions('table.style')
-    else
+    } else {
         style <- match.arg(style)
+    }
     if (is.null(mc$justify)) {
         if (is.null(attr(t, 'alignment'))) {
             if (inherits(t, 'ftable'))
@@ -797,16 +806,20 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     emphasize.parameters <- c('emphasize.rows', 'emphasize.cols', 'emphasize.cells', 'emphasize.strong.rows', 'emphasize.strong.cols', 'emphasize.strong.cells')
     if (all(sapply(emphasize.parameters, function(p) is.null(mc[[p]]), USE.NAMES = FALSE))) {
         ## check if emphasize parameters were set in attributes
-        if (all(sapply(emphasize.parameters, function(p) is.null(attr(t, p)), USE.NAMES = FALSE)))
+        if (all(sapply(emphasize.parameters, function(p) is.null(attr(t, p)), USE.NAMES = FALSE))) {
             t <- get.emphasize(t)
+        }
         ## set emphasize parameters at last
-        for (p in emphasize.parameters)
+        for (p in emphasize.parameters) {
             assign(p, attr(t, p))
+        }
     } else {
         ## some emphasize parameters passed, other should be set to NULL
-        for (p in emphasize.parameters)
-            if (is.null(mc[[p]]))
+        for (p in emphasize.parameters) {
+            if (is.null(mc[[p]])) {
                 assign(p, NULL)
+            }
+        }
     }
     res <- ''
 
@@ -817,8 +830,9 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     t.n <- as.numeric(which(apply(t, 2, is.numeric)))
     if (length(t.n) > 0) {
         t[, t.n] <- apply(t[, t.n, drop = FALSE], 2, round, digits = round)
-        if (!keep.trailing.zeros)
+        if (!keep.trailing.zeros) {
             t[, t.n] <- apply(t[, t.n, drop = FALSE], c(1,2), format, trim = TRUE, digits = digits, decimal.mark = decimal.mark, big.mark = big.mark)
+        }
     }
 
     ## drop unexpected classes and revert back to a common format
@@ -874,10 +888,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     t <- split.large.cells(t)
 
     ## re-set col/rownames to be passed to split tables
-    if (!is.null(t.rownames))
+    if (!is.null(t.rownames)) {
         rownames(t) <- t.rownames
-    if (!is.null(t.colnames))
+    }
+    if (!is.null(t.colnames)) {
         colnames(t) <- t.colnames
+    }
 
     if (!is.null(t.colnames)) {
         t.colnames <- replace(t.colnames, which(t.colnames == ''), '&nbsp;')
@@ -892,58 +908,67 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     t.width <-  as.numeric(apply(cbind(t.colnames.width, apply(t, 2, function(x) max(sapply(strsplit(x,'\n'), function(x) max(nchar(x, type = 'width'), 0))))), 1, max))
 
     ## remove obvious row.names
-    if (all(t.rownames == 1:nrow(t)) | all(t.rownames == ''))
+    if (all(t.rownames == 1:nrow(t)) | all(t.rownames == '')) {
         t.rownames <- NULL
+    }
 
-    if (!is.null(t.rownames) && emphasize.rownames)
+    if (!is.null(t.rownames) && emphasize.rownames) {
         t.rownames <- pandoc.strong.return(t.rownames)
+    }
 
     if (length(t.rownames) != 0) {
 
-        if ((length(split.cells) <= dim(t)[2]) && (length(split.cells) > 1))
+        if ((length(split.cells) <= dim(t)[2]) && (length(split.cells) > 1)) {
             split.cells <- c(panderOptions("table.split.cells"), split.cells)
+        }
         t.rownames <- split.large.cells(t.rownames, TRUE)
 
-        if (!is.null(t.colnames))
+        if (!is.null(t.colnames)) {
             t.colnames <- c('&nbsp;', t.colnames)
+        }
         t.width <- c(max(sapply(strsplit(t.rownames, '\n'), function(x) max(nchar(x, type = 'width'), 0))), t.width)
         t.width[1] <- t.width[1] + 2
 
         ## if we have a non-breaking space in the header
-        if (!is.null(t.colnames))
+        if (!is.null(t.colnames)) {
             t.width[1] <- max(t.width[1], 6)
+        }
 
     }
 
     if (length(justify) != 1) {
-        if (length(justify) != length(t.width))
+        if (length(justify) != length(t.width)) {
             stop(sprintf('Wrong number of parameters (%s instead of *%s*) passed: justify', length(justify), length(t.width)))
+        }
     } else {
         if (all (strsplit(justify, "")[[1]] %in% c("c", "l", "r") )) {
-          if (nchar(justify) != length(t.width))
+          if (nchar(justify) != length(t.width)) {
             stop(sprintf('Wrong number of parameters (%s instead of *%s*) passed: justify', nchar(justify), length(t.width)))
-
+          }
           justify <- c(l = "left", c = "centre", r = "right")[ strsplit(justify, "")[[1]] ]
         } else {
           justify <- rep(justify, length(t.width))
         }
     }
     justify <- sub('^center$', 'centre', justify)
-    if (!all(justify %in% c('left', 'right', 'centre')))
+    if (!all(justify %in% c('left', 'right', 'centre'))) {
         stop('Invalid values passed for `justify` that can be "left", "right" or "centre/center".')
+    }
 
     ## split too wide tables
     if (sum(t.width + 4) > split.tables & length(t.width) > 1 + (length(t.rownames) != 0)) {
 
         t.split <- max(which(cumsum(t.width + 4) > split.tables)[1] - 1, 1)
-        if (t.split == 1 & length(t.rownames) != 0)
+        if (t.split == 1 & length(t.rownames) != 0) {
             t.split <- 2
+        }
 
         ## update caption
-        if (!is.null(caption))
+        if (!is.null(caption)) {
             caption <- paste(caption, panderOptions('table.continues.affix'))
-        else
+        } else {
             caption <- panderOptions('table.continues')
+        }
 
         ## split
         if (length(t.rownames) != 0) {
@@ -1022,21 +1047,24 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         res <- paste0(res, '\n')
         b   <- t
 
-        if (length(t.rownames) != 0)
+        if (length(t.rownames) != 0) {
             b <- cbind(t.rownames, b)
+        }
 
         res <- paste0(res, paste(apply(b, 1, function(x) paste0(table.expand(x, t.width, justify, sep.col), sep.row)), collapse = '\n'))
 
         ## footer
-        if (style != 'grid')
+        if (style != 'grid') {
             res <- paste0(res, sep.btn, '\n\n')
-        else
+        } else {
             res <- paste0(res, '\n\n')
+        }
 
         ## (optional) caption
         check_caption(caption)
-        if (!is.null(caption) && caption != '')
+        if (!is.null(caption) && caption != '') {
             res <- paste0(res, panderOptions('table.caption.prefix'), caption, '\n\n')
+        }
 
         return(res)
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -644,11 +644,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
 
     split.large.cells <- function(cells, for.rownames = FALSE) {
 
-        if (length(split.cells) == 0) {
-            warning("split.cells is a vector of length 0, reverting to default value")
-            split.cells <- panderOptions('table.split.cells')
-        }
-
         ## if we have a single value, extend it to a vector to do less checks laters
         if (length(split.cells) == 1) {
             split.cells <- rep(split.cells, length(cells))
@@ -754,6 +749,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         }
     }
     
+    ## check correct split.cells param
+    if (length(split.cells) == 0) {
+        warning("split.cells is a vector of length 0, reverting to default value")
+        split.cells <- panderOptions('table.split.cells')
+    }
+
     ## check for relative split.cells
     if (all(grepl("%$", split.cells))){
         d <- dim(t)[2]

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -753,7 +753,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
             return(invisible())
         }
     }
-
+    
     ## check for relative split.cells
     if (all(grepl("%$", split.cells))){
         d <- dim(t)[2]
@@ -885,6 +885,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     t.colnames <- tryCatch(colnames(t), error = function(e) NULL)
     t.rownames <- tryCatch(rownames(t), error = function(e) NULL)
 
+    # fixed for incorrect pipilining with rmarkdown (#186)
+    if (style == 'rmarkdown') {
+        t <- apply(t, c(1,2), function(x) gsub("\\|", "\\\\|", x))
+        t.rownames <- sapply(t.rownames, function(x) gsub("\\|", "\\\\|", x))
+    }
+    
     t <- split.large.cells(t)
 
     ## re-set col/rownames to be passed to split tables
@@ -1049,13 +1055,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
 
         ## body
         res <- paste0(res, '\n')
-        b   <- t
 
         if (length(t.rownames) != 0) {
-            b <- cbind(t.rownames, b)
+            t <- cbind(t.rownames, t)
         }
 
-        res <- paste0(res, paste(apply(b, 1, function(x) paste0(table.expand(x, t.width, justify, sep.col), sep.row)), collapse = '\n'))
+        res <- paste0(res, paste(apply(t, 1, function(x) paste0(table.expand(x, t.width, justify, sep.col), sep.row)), collapse = '\n'))
 
         ## footer
         if (style != 'grid') {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -956,9 +956,13 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     }
 
     ## split too wide tables
-    if (sum(t.width + 4) > split.tables & length(t.width) > 1 + (length(t.rownames) != 0)) {
+    extra.spaces.width <- switch(style, # detrmine wheather separator influences column's width (#164)
+                                 'grid'=, 'rmarkdown' = 3, # 3 because 2 spaces and one sep
+                                 'multiline' = ,'simple' = 0)
+    if (sum(t.width + extra.spaces.width) + 1 > split.tables # +1 for the middle separator
+        & length(t.width) > 1 + (length(t.rownames) != 0)) {
 
-        t.split <- max(which(cumsum(t.width + 4) > split.tables)[1] - 1, 1)
+        t.split <- max(which(cumsum(t.width + extra.spaces.width + 1) > split.tables + 1)[1] - 1, 1)
         if (t.split == 1 & length(t.rownames) != 0) {
             t.split <- 2
         }

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -94,7 +94,7 @@ test_that('pandoc.table.return behaves correctly', { # misc tests for uncovered 
     expect_false(any(grep("[[:space:]]$", res)))
     expect_error(pander_return(t, justify="laft")) 
     res <- pander_return(t, split.tables = 1)
-    expect_equal(length(res), 25)
+    expect_equal(length(res), 24)
     res <- pander_return(t, split.cells = c(10, 10, 10))
     expect_equal(length(res), 16)
     expect_warning(pander_return(t, split.cells = vector()))

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -47,16 +47,30 @@ tables <- list(
     table(mtcars$am, mtcars$gear, mtcars$carb) + 0.1
     )
 
+test_that('split.tables', {
+    # test exact values (#164)
+    t <- data.frame(a = '7 chars', b = paste(rep('Δ', 5), collapse = ' '))
+    expect_equal(nchar('Δ Δ Δ Δ Δ', type='width'), 9)
+    res_grid <- pander_return(t, style='grid', split.tables = 23)
+    expect_equal(length(res_grid), 8)
+    expect_false(any(grepl('Table', res_grid)))
+    res_grid <- pander_return(t, style='grid', split.tables = 22)
+    expect_equal(length(res_grid), 18)
+    expect_true(any(grepl('Table', res_grid)))
+    res_simple <- pander_return(t, style='simple', split.tables = 17)
+    expect_equal(length(res_simple), 6)
+    expect_false(any(grepl('Table', res_simple)))
+    res_simple <- pander_return(t, style='simple', split.tables = 16)
+    expect_equal(length(res_simple), 14)
+    expect_true(any(grepl('Table', res_simple)))
+})
+
 dm <- panderOptions('decimal.mark')
 panderOptions('decimal.mark', ',')
 test_that('decimal mark', {
     for (t in tables)
         expect_true(grepl(',', paste(pander_return(t), collapse = '\n')))
 })
-
-## ## manual test
-## for (t in tables)
-##     pander(t)
 
 panderOptions('decimal.mark', dm)
 
@@ -591,7 +605,7 @@ test_that('pander.clogit works correctly', {
     logan2$case <- (logan2$occupation == logan2$tocc)
     res <- pander_return(suppressWarnings(clogit(case ~ tocc + tocc:education + strata(id), logan2)))
     expect_true(grepl("Fitting Conditional logistic regression", res[24]))
-    expect_equal(length(res), 49)
+    expect_equal(length(res), 26)
 })
 
 test_that('pander.zoo works correctly', {
@@ -612,7 +626,7 @@ test_that('pander.lme/pander.summary.lme behaves correctly', {
     sl <- summary(l1)
     pl <- pander_return(l1)
     spl <- pander_return(sl)
-    expect_equal(length(pl), 20)
+    expect_equal(length(pl), 11)
     expect_equal(length(grep('Table', pl)), 1)
     expect_equal(length(spl), 29)
     expect_equal(length(grep('Table', spl)), 3)
@@ -649,8 +663,8 @@ test_that('pander.survfit works correctly', {
     expect_true(any(grepl('Table', res)))
     # using additional options
     res <- pander_return(survfit(Surv(time, status) ~ x, data = aml), print.rmean = T)
-    expect_equal(length(res), 32)
-    expect_equal(res[32], "* restricted mean with upper limit =  103")
+    expect_equal(length(res), 21)
+    expect_equal(res[21], "* restricted mean with upper limit =  103")
 })
 
 test_that('pander.sessionInfo works correctly', {
@@ -677,7 +691,7 @@ test_that('pander.microbenchmark works correctly', {
     suppressMessages(require(microbenchmark))
     res <- pander_return(microbenchmark(paste(1:10), paste0(1:10)))
     expect_true(any(grepl('Unit', res)))
-    expect_equal(length(res), 20)
+    expect_equal(length(res), 11)
     res <- pander_return(microbenchmark(paste(1:10), paste0(1:10)), split.tables = Inf, expr.labels = c("A"))
     expect_true(any(grepl('A', res)))
     expect_true(any(grepl('paste0\\(1:10\\)', res)))

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -80,6 +80,26 @@ test_that('rmarkdown pipe-delimited table is correct (#186)', {
     expect_true(any(grep('my missing cell', res)))
 })
 
+test_that('pandoc.table.return behaves correctly', { # misc tests for uncovered parts
+    expect_warning(pander_return(mtcars[,1:2], split.tables = Inf, split.cells = c("50%", "50%")))
+    t <- mtcars[1:3, 1:2]
+    attr(t, 'alignment') <- 'left'
+    attr(t, 'caption') <- 'simplified mtcars'
+    res <- pander_return(t, emphasize.rownames = F)
+    expect_false(any(grep("^[[:space:]]", res))) # because of left alignment
+    expect_true(any(grep("simplified mtcars", res)))
+    expect_error(pander_return(t, justify = c("left", "right"))) # needs 3 because of rownames
+    expect_error(pander_return(t, justify = "lr")) # needs 3 because of rownames
+    res <- pander_return(t, justify = "lrr")
+    expect_false(any(grep("[[:space:]]$", res)))
+    expect_error(pander_return(t, justify="laft")) 
+    res <- pander_return(t, split.tables = 1)
+    expect_equal(length(res), 25)
+    res <- pander_return(t, split.cells = c(10, 10, 10))
+    expect_equal(length(res), 16)
+    expect_warning(pander_return(t, split.cells = vector()))
+})
+
 dm <- panderOptions('decimal.mark')
 panderOptions('decimal.mark', ',')
 test_that('decimal mark', {

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -65,6 +65,21 @@ test_that('split.tables', {
     expect_true(any(grepl('Table', res_simple)))
 })
 
+test_that('rmarkdown pipe-delimited table is correct (#186)', {
+    d <- data.frame(a = 'foo|bar', b = 'my missing cell')
+    res <- pander_return(d, style='rmarkdown')
+    expect_true(any(grep('foo', res)))
+    expect_true(any(grep('bar', res)))
+    expect_true(any(grep('my missing cell', res)))
+    rownames(d) <- "x|y"
+    res <- pander_return(d, style='rmarkdown')
+    expect_true(any(grep('x', res)))
+    expect_true(any(grep('y', res)))
+    expect_true(any(grep('foo', res)))
+    expect_true(any(grep('bar', res)))
+    expect_true(any(grep('my missing cell', res)))
+})
+
 dm <- panderOptions('decimal.mark')
 panderOptions('decimal.mark', ',')
 test_that('decimal mark', {


### PR DESCRIPTION
I have started working on refactoring `pandoc.table.return` through converting to intermediate representation. As for now I am trying `data.frame` as an [intermediate representation](https://github.com/RomanTsegelskyi/pander/blob/pandoc_refactoring/R/pandoc.R#L738). IMHO that should be a great simplification of many things and I will be pushing new commit as I refactor and test the other parts.