### PR TITLE
Fix for add.significance.stars

### DIFF
--- a/R/S3.R
+++ b/R/S3.R
@@ -323,7 +323,7 @@ pander.summary.lm <- function(x, caption = attr(x, 'caption'), covariate.labels,
         row.names(res)[1:length(covariate.labels)] <- covariate.labels
 
     if (add.significance.stars)
-        res[, 4] <- add.significance.stars(res[, 4])
+        res <- cbind(res, ' '=add.significance.stars(res[, 4]))
 
     if (summary) {
         pandoc.table(res, ...)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -293,8 +293,7 @@ add.significance.stars <- function(p) {
         if (length(p) > 1) {
             sapply(p, add.significance.stars)
         } else {
-            s <- ifelse(p > 0.05, '', ifelse(p > 0.01, ' *', ifelse(p > 0.001, ' * *', ' * * *')))
-            paste0(p(p), s)
+            ifelse(p > 0.05, '', ifelse(p > 0.01, ' *', ifelse(p > 0.001, ' * *', ' * * *')))
         }
     }
 }

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -845,7 +845,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     } else {
       temp.t <- t
     }
-    t.n <- as.numeric(which(apply(t, 2, is.numeric)))
+    t.n <- which(sapply(1:ncol(t),function(x) is.numeric(t[,x])))
     if (length(t.n) > 0) {
         round <- check_digits(round, 'round', ncol(t))
         # for-loop is needed to preserve row/col names and use index to get appropriate value from round vector


### PR DESCRIPTION
Possible fix for #200. @daroczig, what do you think?

```r
> pander(xs, add.significance.stars = TRUE)

----------------------------------------------------------------------
     &nbsp;        Estimate   Std. Error   t value    Pr(>|t|)        
----------------- ---------- ------------ --------- ------------ -----
   **group1**      -0.1855    0.1557174   -1.19126  2.490232e-01      

 **(Intercept)**    4.8465    0.1557174   31.12368  4.185248e-17 * * *
----------------------------------------------------------------------


-------------------------------------------------------------
 Observations   Residual Std. Error   $R^2$   Adjusted $R^2$ 
-------------- --------------------- ------- ----------------
      20              0.6964         0.07308     0.02158     
-------------------------------------------------------------

Table: Fitting linear model: weight ~ group
```