### PR TITLE
total.r and total.c support for CrossTable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,7 @@ Fixes:
  * read default params of set.alignment from panderOptions (#137)
  * render header for 1D tables (#138)
  * emphasize cells with missing/empty values (#156)
+ * total.r and total.c support for CrossTable (#211)
 
 pander 0.5.1 (2014-10-29)
 ----------------------------------------------------------------

--- a/R/S3.R
+++ b/R/S3.R
@@ -835,9 +835,12 @@ pander.mtable <- function(x, caption = attr(x, 'caption'), ...) {
 #' @param x a CrossTable object
 #' @param caption caption (string) to be shown under the table
 #' @param digits number of digits of precision
+#' @param total.r if to print row totals. Default values is taken from CrossTable object
+#' @param total.r if to print column totals. Default values is taken from CrossTable object
 #' @param ... optional parameters passed to raw \code{pandoc.table} function
 #' @export
-pander.CrossTable <- function(x, caption = attr(x, 'caption'), digits = panderOptions("digits"), ...) {
+pander.CrossTable <- function(x, caption = attr(x, 'caption'), digits = panderOptions("digits"),
+                              total.r = x$total.r, total.c = x$total.c, ...) {
     if (is.null(caption) & !is.null(storage$caption)) {
         caption <- get.caption()
     }
@@ -950,6 +953,9 @@ pander.CrossTable <- function(x, caption = attr(x, 'caption'), digits = panderOp
     or <- (nrow(nt) - ts) / nr
     nt.nr <- nrow(nt)
     nc <- ncol(nt)
+    if (!is.null(total.r) && !total.r) {
+        nc <- nc - 1
+    }
     RowData <- x$RowData
     ColData <- x$ColData
     res <- NULL
@@ -967,11 +973,16 @@ pander.CrossTable <- function(x, caption = attr(x, 'caption'), digits = panderOp
         res <- rbind(res, res.r)
     }
     res.r <- NULL
-    for (j in 1:nc) {
-        res.r <- cbind(res.r, paste(nt[ (nt.nr - ts + 1) : nt.nr, j], collapse = "\\ \n"))
+    if (is.null(total.c) || total.c) {
+        for (j in 1:nc) {
+            res.r <- cbind(res.r, paste(nt[ (nt.nr - ts + 1) : nt.nr, j], collapse = "\\ \n"))
+        }
+        res <- rbind(res, res.r)
     }
-    res <- rbind(res, res.r)
-    cln <- c(if (RowData != "") RowData else '&nbsp;', colnames(x$t), 'Total')
+    cln <- c(ifelse(RowData != "", RowData, '&nbsp;'), colnames(x$t))
+    if (is.null(total.r) || total.r) {
+        cln <- c(cln, 'Total')
+    }
     if (ColData != "") {
         cln.t <- paste(c("&nbsp;", ColData, rep("&nbsp;", nc - 2)), rep("\\\n", nc - 1), sep="")
         cln <- paste(cln.t, cln, sep="")

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -551,6 +551,17 @@ test_that('pander.CrossTable behaves correctly', {
     expect_true(any(grepl("Residual", res)))
     expect_true(any(grepl("Std Residual", res)))
     expect_true(any(grepl("Adj Std Resid", res)))
+    # issue 211 support for total.r total.c
+    x <- CrossTable(mtcars$cyl, mtcars$gear)
+    res <- pander_return(x, total.c = FALSE)
+    expect_equal(length(res), 27)
+    expect_equal(length(grep('Total', res)), 4)
+    res <- pander_return(x, total.r = FALSE)
+    expect_equal(length(res), 30)
+    expect_equal(length(grep('Total', res)), 4)
+    res <- pander_return(x)
+    expect_equal(length(res), 30)
+    expect_equal(length(grep('Total', res)), 5)
 })
 
 test_that('pander.NULL behaves correctly', {

--- a/man/pander.CrossTable.Rd
+++ b/man/pander.CrossTable.Rd
@@ -5,7 +5,8 @@
 \title{Pander method for CrossTable class}
 \usage{
 \method{pander}{CrossTable}(x, caption = attr(x, "caption"),
-  digits = panderOptions("digits"), ...)
+  digits = panderOptions("digits"), total.r = x$total.r,
+  total.c = x$total.c, ...)
 }
 \arguments{
 \item{x}{a CrossTable object}
@@ -14,7 +15,11 @@
 
 \item{digits}{number of digits of precision}
 
+\item{total.r}{if to print row totals. Default values is taken from CrossTable object}
+
 \item{...}{optional parameters passed to raw \code{pandoc.table} function}
+
+\item{total.r}{if to print column totals. Default values is taken from CrossTable object}
 }
 \description{
 Prints a CrossTable object in Pandoc's markdown.


### PR DESCRIPTION
As requested in #211 this PR adds support for `total.r` and `total.c`. Default values are taken from `CrossTable` object, but can be overriden if needed. Here is a small example:

```r
> x <- CrossTable(mtcars$cyl, mtcars$gear)
Warning message:
In chisq.test(tab, correct = FALSE, ...) :
  Chi-squared approximation may be incorrect
> 
> pander(x, total.r = FALSE, plain.ascii = TRUE)

---------------------------------------------------
              mtcars$gear                          
 mtcars$cyl        3             4           5     
------------ -------------- ----------- -----------
     4                                             
     N            1             8           2      
Chi-square      3.3502       3.6402      0.0460    
  Row(%)       9.0909%      72.7273%    18.1818%   
 Column(%)     6.6667%      66.6667%    40.0000%   
  Total(%)       3.125%       25.000%     6.250%   

     6                                             
     N            2             4           1      
Chi-square      0.5003       0.7202      0.0080    
  Row(%)       28.5714%     57.1429%    14.2857%   
 Column(%)     13.3333%     33.3333%    20.0000%   
  Total(%)       6.250%       12.500%     3.125%   

     8                                             
     N            12            0           2      
Chi-square      4.5054       5.2500      0.0161    
  Row(%)       85.7143%      0.0000%    14.2857%   
 Column(%)     80.0000%      0.0000%    40.0000%   
  Total(%)      37.500%       0.000%      6.250%   

   Total          15            12          5      
                46.875%        37.5%      15.625%  
---------------------------------------------------

> pander(x, total.c = FALSE, plain.ascii = TRUE)

---------------------------------------------------------------
              mtcars$gear                                      
 mtcars$cyl        3             4           5         Total   
------------ -------------- ----------- ----------- -----------
     4                                                         
     N            1             8           2          11      
Chi-square      3.3502       3.6402      0.0460                
  Row(%)       9.0909%      72.7273%    18.1818%    34.3750%   
 Column(%)     6.6667%      66.6667%    40.0000%               
  Total(%)       3.125%       25.000%     6.250%               

     6                                                         
     N            2             4           1           7      
Chi-square      0.5003       0.7202      0.0080                
  Row(%)       28.5714%     57.1429%    14.2857%    21.8750%   
 Column(%)     13.3333%     33.3333%    20.0000%               
  Total(%)       6.250%       12.500%     3.125%               

     8                                                         
     N            12            0           2          14      
Chi-square      4.5054       5.2500      0.0161                
  Row(%)       85.7143%      0.0000%    14.2857%    43.7500%   
 Column(%)     80.0000%      0.0000%    40.0000%               
  Total(%)      37.500%       0.000%      6.250%               
---------------------------------------------------------------

> pander(x, total.c = FALSE, total.r = FALSE, plain.ascii = TRUE)

---------------------------------------------------
              mtcars$gear                          
 mtcars$cyl        3             4           5     
------------ -------------- ----------- -----------
     4                                             
     N            1             8           2      
Chi-square      3.3502       3.6402      0.0460    
  Row(%)       9.0909%      72.7273%    18.1818%   
 Column(%)     6.6667%      66.6667%    40.0000%   
  Total(%)       3.125%       25.000%     6.250%   

     6                                             
     N            2             4           1      
Chi-square      0.5003       0.7202      0.0080    
  Row(%)       28.5714%     57.1429%    14.2857%   
 Column(%)     13.3333%     33.3333%    20.0000%   
  Total(%)       6.250%       12.500%     3.125%   

     8                                             
     N            12            0           2      
Chi-square      4.5054       5.2500      0.0161    
  Row(%)       85.7143%      0.0000%    14.2857%   
 Column(%)     80.0000%      0.0000%    40.0000%   
  Total(%)      37.500%       0.000%      6.250%   
---------------------------------------------------
```