### PR TITLE
Adding the numeric p-value to the output of class htest, 

### DIFF
--- a/R/S3.R
+++ b/R/S3.R
@@ -557,7 +557,7 @@ pander.htest <- function(x, caption = attr(x, 'caption'), ...) {
         res[names(x$parameter)] <- x$parameter
     }
     if (!is.null(x$p.value)) {
-        res$'P value' <- add.significance.stars(x$p.value)
+        res$'P value' <- c(paste(add.significance.stars(x$p.value), round(x$p.value, 5)))
     }
     if (!is.null(x$alternative)) {
         res['Alternative hypothesis'] <- x$alternative

--- a/R/S3.R
+++ b/R/S3.R
@@ -557,7 +557,12 @@ pander.htest <- function(x, caption = attr(x, 'caption'), ...) {
         res[names(x$parameter)] <- x$parameter
     }
     if (!is.null(x$p.value)) {
-        res$'P value' <- c(paste(add.significance.stars(x$p.value), round(x$p.value, 5)))
+        res$'P value' <- paste(
+          format(round(x$p.value, panderOptions('round')),
+                 trim         = TRUE,
+                 digits       = panderOptions("digits"),
+                 decimal.mark = panderOptions("decimal.mark")),
+          add.significance.stars(x$p.value))
     }
     if (!is.null(x$alternative)) {
         res['Alternative hypothesis'] <- x$alternative


### PR DESCRIPTION
whilst keeping the significance stars.
Maybe one could change the number of digits in the round() function to global pander variable name but I didn't find that on the fly.