### PR TITLE
Update brewer to accomodate R installation change on travis

### DIFF
--- a/.brewer.R
+++ b/.brewer.R
@@ -13,6 +13,7 @@ Pandoc.brew('../inst/README.brew', output = 'index', convert = 'html', open = FA
 t <- readLines('index.html')
 t <- gsub('/usr/lib/R/library/pander/includes//', '', t, fixed = TRUE)
 t <- gsub('/usr/local/lib/R/site-library/pander/includes//', '', t, fixed = TRUE)
+t <- gsub('/home/travis/R/Library/pander/includes//', '', t, fixed = TRUE)
 t <- gsub('/Library/Frameworks/R.framework/Versions/3.2/Resources/library/pander/includes//', '', t, fixed = TRUE)
 
 cat(t, file = 'index.html', sep = '\n')


### PR DESCRIPTION
In #252 it looks like the installation path for R on travis machines has changed, that's so new path was not cleaned up correctly in 8fef7ce. Added the missing replace.