### PR TITLE
add estimate to htest output

### DIFF
--- a/R/S3.R
+++ b/R/S3.R
@@ -579,6 +579,13 @@ pander.htest <- function(x, caption = attr(x, 'caption'), ...) {
     if (!is.null(x$alternative)) {
         res['Alternative hypothesis'] <- x$alternative
     }
+    if (!is.null(x$estimate)) {
+        if (!is.null(names(x$estimate))) {
+            res[names(x$estimate)] <- x$estimate
+        } else {
+            res['Estimate'] <- x$estimate
+        }
+    }
 
     ## drop placeholder
     res$placeholder <- NULL


### PR DESCRIPTION
Some tests (such as fisher.test) report an effect size estimate. This should be reported in the test table.
