### PR TITLE
row.names and col.names argument for pandoc.table()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,13 +4,16 @@ pander DEV (xxxx-xx-xx)
 New classes supported by the `pander` generic S3 method:
  * ets
 
+New features:
+ * pandoc.table gains `row.names` and `col.names` arguments
+
 pander 0.6.0 (2015-10-27)
 ----------------------------------------------------------------
 
 This is a major release with 200+ new commits since last version:
   https://github.com/Rapporter/pander/compare/v0.5.2...v0.6.0
 
-New fetures:
+New features:
  * added logging for evals using futile.logger (#124)
  * added support for digits/round as a vector (#146)
  * added support for emphasize.verbatim (#221)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -492,8 +492,7 @@ pandoc.list <- function(...)
 #' For more details please see the parameters above and passed arguments of \code{\link{panderOptions}}.
 #' @param t data frame, matrix or table
 #' @param caption caption (string) to be shown under the table
-#' @param row.names a logical value indicating whether to include row names; by
-#'   default, row names are included if \code{rownames(x)} is neither
+#' @param row.names if \code{FALSE}, row names are suppressed. A character vector of row names can also be specified here. By default, row names are included if \code{rownames(t)} is neither
 #'   \code{NULL} nor identical to \code{1:nrow(x)}
 #' @param col.names a character vector of column names to be used in the table
 #' @param digits passed to \code{format}. Can be a vector specifying values for each column (has to be the same length as number of columns).

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -632,17 +632,6 @@ pandoc.list <- function(...)
 #' pandoc.table(x, split.cells = 10, use.hyphening = TRUE)
 pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), decimal.mark = panderOptions('decimal.mark'), big.mark = panderOptions('big.mark'), round = panderOptions('round'), missing = panderOptions('missing'), justify, style = c('multiline', 'grid', 'simple', 'rmarkdown'), split.tables = panderOptions('table.split.table'), split.cells = panderOptions('table.split.cells'), keep.trailing.zeros = panderOptions('keep.trailing.zeros'), keep.line.breaks = panderOptions('keep.line.breaks'), plain.ascii = panderOptions('plain.ascii'), use.hyphening = panderOptions('use.hyphening'), row.names, col.names, emphasize.rownames = panderOptions('table.emphasize.rownames'), emphasize.rows, emphasize.cols, emphasize.cells, emphasize.strong.rows, emphasize.strong.cols, emphasize.strong.cells, emphasize.italics.rows, emphasize.italics.cols, emphasize.italics.cells, emphasize.verbatim.rows, emphasize.verbatim.cols, emphasize.verbatim.cells, ...) { #nolint
 
-    if (!missing(row.names)) {
-      if (row.names[1] == FALSE) {
-        rownames(t) <- NULL
-      } else {
-        rownames(t) <- row.names
-      }
-    }
-    if (!missing(col.names)) {
-      colnames(t) <- col.names
-    }
-
     ## expands cells for output
     table.expand <- function(cells, cols.width, justify, sep.cols) {
         .Call('pander_tableExpand_cpp', PACKAGE = 'pander', cells, cols.width, justify, sep.cols, style)
@@ -894,6 +883,16 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         style <- panderOptions('table.style')
     } else {
         style <- match.arg(style)
+    }
+    if (!missing(row.names)) {
+      if (row.names[1] == FALSE) {
+        rownames(t) <- NULL
+      } else {
+        rownames(t) <- row.names
+      }
+    }
+    if (!missing(col.names)) {
+      colnames(t) <- col.names
     }
     if (is.null(mc$justify)) {
         if (is.null(attr(t, 'alignment'))) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -492,9 +492,6 @@ pandoc.list <- function(...)
 #' For more details please see the parameters above and passed arguments of \code{\link{panderOptions}}.
 #' @param t data frame, matrix or table
 #' @param caption caption (string) to be shown under the table
-#' @param row.names if \code{FALSE}, row names are suppressed. A character vector of row names can also be specified here. By default, row names are included if \code{rownames(t)} is neither
-#'   \code{NULL} nor identical to \code{1:nrow(x)}
-#' @param col.names a character vector of column names to be used in the table
 #' @param digits passed to \code{format}. Can be a vector specifying values for each column (has to be the same length as number of columns).
 #' @param decimal.mark passed to \code{format}
 #' @param big.mark passed to \code{format}
@@ -508,6 +505,9 @@ pandoc.list <- function(...)
 #' @param keep.line.breaks (default: \code{FALSE}) if to keep or remove line breaks from cells in a table
 #' @param plain.ascii (default: \code{FALSE}) if output should be in plain ascii (without markdown markup) or not
 #' @param use.hyphening boolean (default: \code{FALSE}) if try to use hyphening when splitting large cells according to table.split.cells. Requires koRpus package.
+#' @param row.names if \code{FALSE}, row names are suppressed. A character vector of row names can also be specified here. By default, row names are included if \code{rownames(t)} is neither
+#'   \code{NULL} nor identical to \code{1:nrow(x)}
+#' @param col.names a character vector of column names to be used in the table
 #' @param emphasize.rownames boolean (default: \code{TRUE}) if row names should be highlighted
 #' @param emphasize.rows deprecated for \code{emphasize.italics.rows} argument
 #' @param emphasize.cols deprecated for \code{emphasize.italics.cols} argument
@@ -630,7 +630,7 @@ pandoc.list <- function(...)
 #' x <- data.frame(a = "Can be also supplied as a vector, for each cell separately",
 #'        b = "Can be also supplied as a vector, for each cell separately")
 #' pandoc.table(x, split.cells = 10, use.hyphening = TRUE)
-pandoc.table.return <- function(t, caption, row.names, col.names, digits = panderOptions('digits'), decimal.mark = panderOptions('decimal.mark'), big.mark = panderOptions('big.mark'), round = panderOptions('round'), missing = panderOptions('missing'), justify, style = c('multiline', 'grid', 'simple', 'rmarkdown'), split.tables = panderOptions('table.split.table'), split.cells = panderOptions('table.split.cells'), keep.trailing.zeros = panderOptions('keep.trailing.zeros'), keep.line.breaks = panderOptions('keep.line.breaks'), plain.ascii = panderOptions('plain.ascii'), use.hyphening = panderOptions('use.hyphening'), emphasize.rownames = panderOptions('table.emphasize.rownames'), emphasize.rows, emphasize.cols, emphasize.cells, emphasize.strong.rows, emphasize.strong.cols, emphasize.strong.cells, emphasize.italics.rows, emphasize.italics.cols, emphasize.italics.cells, emphasize.verbatim.rows, emphasize.verbatim.cols, emphasize.verbatim.cells, ...) { #nolint
+pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), decimal.mark = panderOptions('decimal.mark'), big.mark = panderOptions('big.mark'), round = panderOptions('round'), missing = panderOptions('missing'), justify, style = c('multiline', 'grid', 'simple', 'rmarkdown'), split.tables = panderOptions('table.split.table'), split.cells = panderOptions('table.split.cells'), keep.trailing.zeros = panderOptions('keep.trailing.zeros'), keep.line.breaks = panderOptions('keep.line.breaks'), plain.ascii = panderOptions('plain.ascii'), use.hyphening = panderOptions('use.hyphening'), row.names, col.names, emphasize.rownames = panderOptions('table.emphasize.rownames'), emphasize.rows, emphasize.cols, emphasize.cells, emphasize.strong.rows, emphasize.strong.cols, emphasize.strong.cells, emphasize.italics.rows, emphasize.italics.cols, emphasize.italics.cells, emphasize.verbatim.rows, emphasize.verbatim.cols, emphasize.verbatim.cells, ...) { #nolint
 
     if (!missing(row.names)) {
       if (row.names[1] == FALSE) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -492,6 +492,10 @@ pandoc.list <- function(...)
 #' For more details please see the parameters above and passed arguments of \code{\link{panderOptions}}.
 #' @param t data frame, matrix or table
 #' @param caption caption (string) to be shown under the table
+#' @param row.names a logical value indicating whether to include row names; by
+#'   default, row names are included if \code{rownames(x)} is neither
+#'   \code{NULL} nor identical to \code{1:nrow(x)}
+#' @param col.names a character vector of column names to be used in the table
 #' @param digits passed to \code{format}. Can be a vector specifying values for each column (has to be the same length as number of columns).
 #' @param decimal.mark passed to \code{format}
 #' @param big.mark passed to \code{format}
@@ -627,7 +631,18 @@ pandoc.list <- function(...)
 #' x <- data.frame(a = "Can be also supplied as a vector, for each cell separately",
 #'        b = "Can be also supplied as a vector, for each cell separately")
 #' pandoc.table(x, split.cells = 10, use.hyphening = TRUE)
-pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), decimal.mark = panderOptions('decimal.mark'), big.mark = panderOptions('big.mark'), round = panderOptions('round'), missing = panderOptions('missing'), justify, style = c('multiline', 'grid', 'simple', 'rmarkdown'), split.tables = panderOptions('table.split.table'), split.cells = panderOptions('table.split.cells'), keep.trailing.zeros = panderOptions('keep.trailing.zeros'), keep.line.breaks = panderOptions('keep.line.breaks'), plain.ascii = panderOptions('plain.ascii'), use.hyphening = panderOptions('use.hyphening'), emphasize.rownames = panderOptions('table.emphasize.rownames'), emphasize.rows, emphasize.cols, emphasize.cells, emphasize.strong.rows, emphasize.strong.cols, emphasize.strong.cells, emphasize.italics.rows, emphasize.italics.cols, emphasize.italics.cells, emphasize.verbatim.rows, emphasize.verbatim.cols, emphasize.verbatim.cells, ...) { #nolint
+pandoc.table.return <- function(t, caption, row.names, col.names, digits = panderOptions('digits'), decimal.mark = panderOptions('decimal.mark'), big.mark = panderOptions('big.mark'), round = panderOptions('round'), missing = panderOptions('missing'), justify, style = c('multiline', 'grid', 'simple', 'rmarkdown'), split.tables = panderOptions('table.split.table'), split.cells = panderOptions('table.split.cells'), keep.trailing.zeros = panderOptions('keep.trailing.zeros'), keep.line.breaks = panderOptions('keep.line.breaks'), plain.ascii = panderOptions('plain.ascii'), use.hyphening = panderOptions('use.hyphening'), emphasize.rownames = panderOptions('table.emphasize.rownames'), emphasize.rows, emphasize.cols, emphasize.cells, emphasize.strong.rows, emphasize.strong.cols, emphasize.strong.cells, emphasize.italics.rows, emphasize.italics.cols, emphasize.italics.cells, emphasize.verbatim.rows, emphasize.verbatim.cols, emphasize.verbatim.cells, ...) { #nolint
+
+    if (!missing(row.names)) {
+      if (row.names[1] == FALSE) {
+        rownames(t) <- NULL
+      } else {
+        rownames(t) <- row.names
+      }
+    }
+    if (!missing(col.names)) {
+      colnames(t) <- col.names
+    }
 
     ## expands cells for output
     table.expand <- function(cells, cols.width, justify, sep.cols) {
@@ -900,6 +915,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
         }
     }
 
+
     ## check if emphasize parameters were passed
     emphasize.parameters <- c('emphasize.rows',
                               'emphasize.cols',
@@ -1078,7 +1094,7 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     t.colnames <- tryCatch(colnames(t), error = function(e) NULL)
     t.rownames <- tryCatch(rownames(t), error = function(e) NULL)
 
-    ## fixed for incorrect pipilining with rmarkdown (#186)
+    ## fixed for incorrect pipelining with rmarkdown (#186)
     if (style == 'rmarkdown') {
         t <- apply(t, c(1,2), function(x) gsub('\\|', '\\\\|', x)) #nolint
         t.rownames <- sapply(t.rownames, function(x) gsub('\\|', '\\\\|', x)) #nolint

--- a/inst/tests/test-S3.R
+++ b/inst/tests/test-S3.R
@@ -251,6 +251,38 @@ evalsOptions('cache.dir',  cache.dir)
 evalsOptions('graph.dir',  graph.dir)
 setwd(wd)
 
+context('row and column names')
+
+library(testthat)
+library(pander)
+
+tables <- list(
+  mtcars[1:2, 1:2],
+  data.frame(x = 1:2, y = 2:3),
+  data.frame(x = 1:3, y = 2:4)[c(1, 3), ]
+  )
+
+t <- tables[[1]]
+
+test_that('row names can be suppressed', {
+  for (t in tables) {
+    expect_false(grepl("&nbsp;", pandoc.table.return(t, row.names = FALSE)))
+  }
+})
+
+test_that('row names can be set', {
+  for (t in tables) {
+    expect_true(grepl("\\n \\*\\*a\\*\\*", pandoc.table.return(t, row.names = c("a", "b"))))
+  }
+})
+
+test_that('column names can be set', {
+  for (t in tables) {
+    res <- capture.output(pandoc.table(t, col.names = c("a", "b")))
+    expect_true(grepl("a *b", res[3]))
+  }
+})
+
 context('default alignments')
 
 tables <- list(


### PR DESCRIPTION
I think these arguments are important, therefore I propose to place
them early in the argument list. This is a matter of opinion of course.
I tried to use match.arg on these, but it throws an error. Maybe the
arguments need to be renamed for this to work, but I think it's good to
be compatible to knitr::kable() regarding the naming of the arguments.

I also tried to place the code later in the function definition of
pandoc.table, where the other arguments are initialized, but then it
fails when row.names is set to FALSE, so it seems some code uses
the row names before that place.

Closes #281.
