### PR TITLE
Moved calls to 'to.plain.ascii' before the column widths are calculated (fix for issue #321)

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -1124,6 +1124,12 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
     ## #########################################################################
     ## compute column width
     ## #########################################################################
+    
+    if (plain.ascii) {
+      t <- apply(t, c(1, 2), to.plain.ascii)
+      t.rownames <- sapply(t.rownames, to.plain.ascii)
+      t.colnames <- sapply(t.colnames, to.plain.ascii)
+    }
 
     ## header width
     if (!is.null(t.colnames)) {
@@ -1310,12 +1316,6 @@ pandoc.table.return <- function(t, caption, digits = panderOptions('digits'), de
                    sep.hdr <- align.hdr(t.width, justify)
                    sep.col <- c('| ', ' | ', ' |')
                })
-
-        if (plain.ascii){
-            t <- apply(t, c(1, 2), to.plain.ascii)
-            t.rownames <- sapply(t.rownames, to.plain.ascii)
-            t.colnames <- sapply(t.colnames, to.plain.ascii)
-        }
 
         ## #########################################################################
         ## Actual printing starts here


### PR DESCRIPTION
Ran all tests on Linux and Windows and no detectable errors are introduced.

In the example I gave, when I opened the issue, we had:

```
pander(obj, style = "multiline", plain.ascii = TRUE, justify = "left", 
       keep.line.breaks = TRUE, split.tables = Inf, split.cells = Inf)

# -----------------------------------------------------------------------
# Variable    Text Graph                              Valid     Missing  
# ----------- --------------------------------------- --------- ---------
# age         .     .         .   . :                 975       25       
# [numeric]   : . . : : :   : : . : :                 (97.5%)   (2.5%)   
#             : : : : : : : : : : : :                                    
#             : : : : : : : : : : : :                                    
#             : : : : : : : : : : : :                                    
#             : : : : : : : : : : : :                                    
# -----------------------------------------------------------------------
```

After the change, we have:

```
# ---------------------------------------------------------
# Variable    Text Graph                Valid     Missing  
# ----------- ------------------------- --------- ---------
# age         .     .         .   . :   975       25       
# [numeric]   : . . : : :   : : . : :   (97.5%)   (2.5%)   
#             : : : : : : : : : : : :                      
#             : : : : : : : : : : : :                      
#             : : : : : : : : : : : :                      
#             : : : : : : : : : : : :                      
# ---------------------------------------------------------
```
